### PR TITLE
fix: Replace hardcoded admin ID with proper MongoDB ObjectId

### DIFF
--- a/frontend/src/app/api/auth/me/route.ts
+++ b/frontend/src/app/api/auth/me/route.ts
@@ -18,7 +18,20 @@ export async function GET(request: NextRequest) {
 
     const decoded = jwt.verify(token, process.env.JWT_SECRET!) as any;
     
-    const user = await User.findById(decoded.id).select('-password');
+    let user;
+    // Handle hardcoded admin ID case
+    if (decoded.id === 'admin_hardcoded') {
+      user = await User.findOne({ 
+        role: 'admin',
+        $or: [
+          { email: 'admin@formulytic.com' },
+          { username: 'admin' }
+        ]
+      }).select('-password');
+    } else {
+      user = await User.findById(decoded.id).select('-password');
+    }
+    
     if (!user) {
       return NextResponse.json({ message: 'User not found' }, { status: 404 });
     }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -39,8 +39,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const fetchUserData = async () => {
     try {
-      // Use the frontend API route instead of direct backend call
-      const response = await axios.get('/api/auth/me');
+      // Use the backend server directly instead of frontend API route
+      const response = await axios.get(`${ServerLink}/auth/me`);
       setUser(response.data.user);
     } catch (error) {
       console.error('Failed to fetch user data:', error);


### PR DESCRIPTION
- Updated backend auth login to create/use real admin user from database
- Fixed AuthContext to use backend server for user data fetching
- Ensures admin login returns proper ObjectId instead of 'admin_hardcoded'
- Maintains backward compatibility with hardcoded admin credentials
- Fixes CastError when accessing /api/auth/me with invalid ObjectId

This resolves the admin dashboard loading issues by ensuring all user operations use valid MongoDB ObjectIds.